### PR TITLE
Discharge - representation bug

### DIFF
--- a/app/views/transactions/charge/tasks.html
+++ b/app/views/transactions/charge/tasks.html
@@ -128,7 +128,7 @@
 
               <tr class="govuk-table__row">
               <td class="govuk-table__cell">
-              <a href="discharge/lender-representation" class="govuk-link">Add lender representation</a>
+              <a href="/../transactions/discharge/lender-representation" class="govuk-link">Add lender representation</a>
               </td>
 
               <td class="govuk-table__cell">


### PR DESCRIPTION
Fix for bug: when 'I'll submit discharge later' was selected, dead link appeared for lender representation. 