### PR TITLE
Fixing warning statement alignment for transferor POA journey

### DIFF
--- a/app/views/transactions/transfer/transferor-POA-2.html
+++ b/app/views/transactions/transfer/transferor-POA-2.html
@@ -127,9 +127,9 @@
             Add another attorney
             </a>
 
-            <div class="govuk-warning-text" style="margin-top: -50px;">
+            <div class="govuk-warning-text">
               <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-              <strong class="govuk-warning-text__text" style="margin-top: 50px;">
+              <strong class="govuk-warning-text__text">
                 <span class="govuk-warning-text__assistive">Warning</span>
                 Naming errors lead to requisitions. By selecting ‘Continue’ you confirm names are correct.
               </strong>

--- a/app/views/transactions/transfer/transferor-POA-3-removed.html
+++ b/app/views/transactions/transfer/transferor-POA-3-removed.html
@@ -127,9 +127,9 @@
             Add another attorney
             </a>
 
-            <div class="govuk-warning-text" style="margin-top: -50px;">
+            <div class="govuk-warning-text">
               <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-              <strong class="govuk-warning-text__text" style="margin-top: 50px;">
+              <strong class="govuk-warning-text__text">
                 <span class="govuk-warning-text__assistive">Warning</span>
                 Naming errors lead to requisitions. By selecting ‘Continue’ you confirm names are correct.
               </strong>

--- a/app/views/transactions/transfer/transferor-POA-3.html
+++ b/app/views/transactions/transfer/transferor-POA-3.html
@@ -164,9 +164,9 @@
             Add another attorney
             </a>
 
-            <div class="govuk-warning-text" style="margin-top: -50px;">
+            <div class="govuk-warning-text">
               <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-              <strong class="govuk-warning-text__text" style="margin-top: 50px;">
+              <strong class="govuk-warning-text__text">
                 <span class="govuk-warning-text__assistive">Warning</span>
                 Naming errors lead to requisitions. By selecting ‘Continue’ you confirm names are correct.
               </strong>

--- a/app/views/transactions/transfer/transferor-POA-removed.html
+++ b/app/views/transactions/transfer/transferor-POA-removed.html
@@ -99,9 +99,9 @@
 
 
               <br><br>
-            <div class="govuk-!-width-full govuk-warning-text" style="margin-top: -50px;">
+            <div class="govuk-!-width-full govuk-warning-text">
               <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-              <strong class="govuk-warning-text__text" style="margin-top: 50px;">
+              <strong class="govuk-warning-text__text">
                 <span class="govuk-warning-text__assistive">Warning</span>
                 Naming errors lead to requisitions. By selecting ‘Continue’ you confirm names are correct.
 

--- a/app/views/transactions/transfer/transferor-POA.html
+++ b/app/views/transactions/transfer/transferor-POA.html
@@ -99,9 +99,9 @@
 
 
               <br><br>
-            <div class="govuk-!-width-full govuk-warning-text" style="margin-top: -50px;">
+            <div class="govuk-!-width-full govuk-warning-text" style="">
               <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-              <strong class="govuk-warning-text__text" style="margin-top: 50px;">
+              <strong class="govuk-warning-text__text">
                 <span class="govuk-warning-text__assistive">Warning</span>
                 Naming errors lead to requisitions. By selecting ‘Continue’ you confirm names are correct.
 


### PR DESCRIPTION
Removed margins previously required - warning statement now working normally without css for some reason.